### PR TITLE
SYSPROP-5 NPE when upload new attachment where old content not exists

### DIFF
--- a/src/main/java/org/xwiki/contrib/systemproperties/internal/SystemPropertiesUpdaterManager.java
+++ b/src/main/java/org/xwiki/contrib/systemproperties/internal/SystemPropertiesUpdaterManager.java
@@ -174,10 +174,12 @@ public class SystemPropertiesUpdaterManager
                 XWikiDocument document = xwiki.getDocument(reference.getDocumentReference(), context);
                 XWikiAttachment attachment = new XWikiAttachment(document, reference.getName());
                 InputStream currentAttachmentIS = attachment.getContentInputStream(context);
-                byte[] currentAttachmentBytes = IOUtils.toByteArray(currentAttachmentIS);
-                currentAttachmentIS.close();
-                byte[] currentAttachmentSum = digest.digest(currentAttachmentBytes);
-
+                byte[] currentAttachmentSum = null;
+                if (currentAttachmentIS != null) {
+                    byte[] currentAttachmentBytes = IOUtils.toByteArray(currentAttachmentIS);
+                    currentAttachmentIS.close();
+                    currentAttachmentSum = digest.digest(currentAttachmentBytes);
+                }
                 if (currentAttachmentSum != newAttachmentSum) {
                     attachment.setContent(new ByteArrayInputStream(newFileBytes));
                     document.setAttachment(attachment);


### PR DESCRIPTION
To upload new attachments, currentAttachmentIS is _null_ leading to NPE. 

I have added a simple check to prevent NPE and let code save new attachment. 